### PR TITLE
Address Bug in Serializing Two Step Computables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ FIRO_TSEnsembles/build/**
 ensemble-view/build/**
 ensemble-dss/bin/**
 ensemble-dss/build/**
+FIRO_TSEnsembles/delete_me3321028155427948925.sqlite
+FIRO_TSEnsembles/delete_me6470038471526261174.sqlite
+FIRO_TSEnsembles/delete_me5124707431396663684.sqlite

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/Serializer.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/Serializer.java
@@ -40,7 +40,7 @@ public final class Serializer {
                         double doubleVal = (double) objectFieldValue;
                         attribute = Double.toString(doubleVal);
                         break;
-                    case "java.lang.Integer":
+                    case "int":
                         int intValue = (int) objectFieldValue;
                         attribute = Integer.toString(intValue);
                         break;
@@ -61,6 +61,18 @@ public final class Serializer {
                         Element computableEle = Serializer.toXML(computable); //recursive call
                         computableEle.setAttribute("fieldName", fieldName);
                         ele.addContent(computableEle);
+                        break;
+                    case "hec.ensemble.stats.MultiComputable":
+                        MultiComputable mcomputable = (MultiComputable) objectFieldValue;
+                        Element mcomputableEle = Serializer.toXML(mcomputable); //recursive call
+                        mcomputableEle.setAttribute("fieldName", fieldName);
+                        ele.addContent(mcomputableEle);
+                        break;
+                    case "hec.ensemble.stats.SingleComputable":
+                        SingleComputable scomputable = (SingleComputable) objectFieldValue;
+                        Element scomputableEle = Serializer.toXML(scomputable); //recursive call
+                        scomputableEle.setAttribute("fieldName", fieldName);
+                        ele.addContent(scomputableEle);
                         break;
                     case "boolean":
                         boolean bool = (boolean)objectFieldValue;
@@ -148,6 +160,28 @@ public final class Serializer {
                             String elementFieldName = childElement.getAttributeValue("fieldName");
                             if(elementFieldName.equals(fieldName)){
                                 Computable computer = Serializer.fromXML(childElement);
+                                field.set(computable, computer);
+                            }
+                        }
+                        break;
+                    case "hec.ensemble.stats.MultiComputable":
+                        List<Object> mchilds =  ele.getChildren();
+                        for( Object child: mchilds){
+                            Element childElement = (Element)child;
+                            String elementFieldName = childElement.getAttributeValue("fieldName");
+                            if(elementFieldName.equals(fieldName)){
+                                MultiComputable computer = Serializer.fromXML(childElement);
+                                field.set(computable, computer);
+                            }
+                        }
+                        break;
+                    case "hec.ensemble.stats.SingleComputable":
+                        List<Object> schilds =  ele.getChildren();
+                        for( Object child: schilds){
+                            Element childElement = (Element)child;
+                            String elementFieldName = childElement.getAttributeValue("fieldName");
+                            if(elementFieldName.equals(fieldName)){
+                                SingleComputable computer = Serializer.fromXML(childElement);
                                 field.set(computable, computer);
                             }
                         }

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/Serializer.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/Serializer.java
@@ -52,11 +52,11 @@ public final class Serializer {
                         float[] floatArray = (float[]) objectFieldValue;
                         attribute = Arrays.toString(floatArray);
                         break;
-                    case "hec.stats.Statistics[]":
+                    case "hec.ensemble.stats.Statistics[]":
                         Statistics[] stats = (Statistics[]) objectFieldValue;
                         attribute = Arrays.toString(stats);
                         break;
-                    case "hec.stats.Computable":
+                    case "hec.ensemble.stats.Computable":
                         Computable computable = (Computable) objectFieldValue;
                         Element computableEle = Serializer.toXML(computable); //recursive call
                         computableEle.setAttribute("fieldName", fieldName);
@@ -129,7 +129,7 @@ public final class Serializer {
                         }
                         field.set(computable, floats);
                         break;
-                    case "hec.stats.Statistics[]":
+                    case "hec.ensemble.stats.Statistics[]":
                         if(attributeValue == null){
                             continue;
                         }
@@ -141,7 +141,7 @@ public final class Serializer {
                         }
                         field.set(computable, statsArray);
                         break;
-                    case "hec.stats.Computable":
+                    case "hec.ensemble.stats.Computable":
                         List<Object> childs =  ele.getChildren();
                         for( Object child: childs){
                             Element childElement = (Element)child;

--- a/FIRO_TSEnsembles/src/main/java/hec/stats/Serializer.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/stats/Serializer.java
@@ -91,26 +91,36 @@ public final class Serializer {
 
                 int modifiers = field.getModifiers();
                 if (Modifier.isProtected(modifiers)) {
-                    System.out.println("protected");
+                    System.out.println("protected, so we did nothing: " +fieldName);
                 } else if (Modifier.isPrivate(modifiers)) {
                     field.setAccessible(true);
-                    System.out.println("private");
+                    System.out.println("private field set accessible: " + fieldName );
                 }
 
                 String attributeValue = ele.getAttributeValue(fieldName);
-                if(attributeValue == null){
-                    continue;
-                }
+
                 switch (stringType) {
                     case "java.lang.Double":
+                        if(attributeValue == null){
+                            continue;
+                        }
                         field.set(computable, Double.parseDouble(attributeValue));
                         break;
                     case "java.lang.Integer":
+                        if(attributeValue == null){
+                            continue;
+                        }
                         field.set(computable, Integer.parseInt(attributeValue));
                         break;
                     case "java.lang.float":
+                        if(attributeValue == null){
+                            continue;
+                        }
                         field.set(computable, Float.parseFloat(attributeValue));
                     case "float[]":
+                        if(attributeValue == null){
+                            continue;
+                        }
                         String[] floatStringSplit = prepareXMLArray(attributeValue);
                         float[] floats = new float[floatStringSplit.length];
                         for (int i = 0; i < floatStringSplit.length; i++) {
@@ -120,6 +130,9 @@ public final class Serializer {
                         field.set(computable, floats);
                         break;
                     case "hec.stats.Statistics[]":
+                        if(attributeValue == null){
+                            continue;
+                        }
                         String[] statisticsStringSplit = prepareXMLArray(attributeValue);
                         Statistics[] statsArray = new Statistics[statisticsStringSplit.length];
                         for (int i = 0; i < statisticsStringSplit.length; i++) {
@@ -132,7 +145,7 @@ public final class Serializer {
                         List<Object> childs =  ele.getChildren();
                         for( Object child: childs){
                             Element childElement = (Element)child;
-                            String elementFieldName = childElement.getAttribute("fieldName").toString();
+                            String elementFieldName = childElement.getAttributeValue("fieldName");
                             if(elementFieldName.equals(fieldName)){
                                 Computable computer = Serializer.fromXML(childElement);
                                 field.set(computable, computer);

--- a/FIRO_TSEnsembles/src/test/java/hec/stats/SingleComputableTest.java
+++ b/FIRO_TSEnsembles/src/test/java/hec/stats/SingleComputableTest.java
@@ -18,6 +18,8 @@ class SingleComputableTest {
             SingleComputable A = Serializer.fromXML(a);
             SingleComputable B = Serializer.fromXML(b);
 
+            System.out.println("uhhh");
+
         } catch (Exception exception) {
             exception.printStackTrace();
             fail();

--- a/FIRO_TSEnsembles/src/test/java/hec/stats/SingleComputableTest.java
+++ b/FIRO_TSEnsembles/src/test/java/hec/stats/SingleComputableTest.java
@@ -8,7 +8,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class SingleComputableTest {
     SingleComputable maxOfMax = new MaxOfMaximumsComputable();
-    SingleComputable twostep = new TwoStepComputable(new MaxComputable(),new MeanComputable(), true);
+    Statistics[] stats = new Statistics[]{Statistics.MAX};
+    MultiComputable mc = new MultiStatComputable(stats);
+    NDayMultiComputable nday = new NDayMultiComputable(mc,2);
+    SingleComputable twostep = new TwoStepComputable(nday,new MeanComputable(), true);
 
     @Test
     void ToAndFromXML() {


### PR DESCRIPTION
Two step computables weren't loading from XML correctly due to some minor issues. I was skipping things too aggressively, and made a bad .ToString() call. 