### PR TITLE
Fix to compute metrics in ensemble viewer

### DIFF
--- a/FIRO_TSEnsembles/src/main/java/hec/metrics/MetricCollection.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/metrics/MetricCollection.java
@@ -62,7 +62,8 @@ public class MetricCollection {
     //probably need getdataforparametername.
 
     public float[] getDateForStatistic(Statistics stat){
-        int index = Arrays.asList(metric_statisticsLabel).indexOf(stat);
+        String[] splitString = metric_statisticsLabel.split(",");
+        int index = Arrays.asList(splitString).indexOf(stat.toString());
         if (index >= 0) {
             return metrics[index];
         }

--- a/FIRO_TSEnsembles/src/main/java/hec/metrics/MetricCollection.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/metrics/MetricCollection.java
@@ -62,7 +62,7 @@ public class MetricCollection {
     //probably need getdataforparametername.
 
     public float[] getDateForStatistic(Statistics stat){
-        String[] splitString = metric_statisticsLabel.split(",");
+        String[] splitString = metric_statisticsLabel.split("[|,]");
         int index = Arrays.asList(splitString).indexOf(stat.toString());
         if (index >= 0) {
             return metrics[index];


### PR DESCRIPTION
Change String to String array for MetricCollection::getDateForStatistics method

Fix #150.