### PR TITLE
Fix and refactored MetricCollection::getComputedValuesForStatistic

### DIFF
--- a/FIRO_TSEnsembles/src/main/java/hec/metrics/MetricCollection.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/metrics/MetricCollection.java
@@ -61,12 +61,11 @@ public class MetricCollection {
     }
     //probably need getdataforparametername.
 
-    public float[] getDateForStatistic(Statistics stat){
-        String[] splitString = metric_statisticsLabel.split("[|,]");
-        int index = Arrays.asList(splitString).indexOf(stat.toString());
-        if (index >= 0) {
-            return metrics[index];
+    public float[] getComputedValuesForStatistic(Statistics stat){
+        if (metric_statisticsLabel.contains(stat.toString())) {
+            return metrics[0];
+        } else {
+            throw new IllegalArgumentException(stat + " does not match " + metric_statisticsLabel);
         }
-        return null;
     }
 }

--- a/ensemble-view/src/main/java/hec/ensembleview/StatComputationHelper.java
+++ b/ensemble-view/src/main/java/hec/ensembleview/StatComputationHelper.java
@@ -106,10 +106,10 @@ public class StatComputationHelper {
     static private float[] computeStatFromMultiStatComputable(EnsembleTimeSeries ets, Statistics stat, ZonedDateTime selectedZdt, ChartType chartType) {
         if(chartType == ChartType.TimePlot) {
             MetricCollectionTimeSeries mct = ets.iterateAcrossTimestepsOfEnsemblesWithMultiComputable(new MultiStatComputable(new Statistics[]{stat}));
-            return mct.getMetricCollection(selectedZdt).getDateForStatistic(stat);
+            return mct.getMetricCollection(selectedZdt).getComputedValuesForStatistic(stat);
         } else if (chartType == ChartType.ScatterPlot) {
             MetricCollectionTimeSeries mct = ets.iterateAcrossTracesOfEnsemblesWithMultiComputable(new MultiStatComputable(new Statistics[] {stat}));
-            return mct.getMetricCollection(selectedZdt).getDateForStatistic(stat);
+            return mct.getMetricCollection(selectedZdt).getComputedValuesForStatistic(stat);
         }
         return null;
     }
@@ -117,10 +117,10 @@ public class StatComputationHelper {
     static private float[] computeStatFromPercentilesComputable(EnsembleTimeSeries ets, Statistics stat, ZonedDateTime selectedZdt, float[] percentiles, ChartType chartType) {
         if(chartType == ChartType.TimePlot) {
             MetricCollectionTimeSeries mct = ets.iterateAcrossTimestepsOfEnsemblesWithMultiComputable(new PercentilesComputable(percentiles));
-            return mct.getMetricCollection(selectedZdt).getDateForStatistic(stat);
+            return mct.getMetricCollection(selectedZdt).getComputedValuesForStatistic(stat);
         } else if (chartType == ChartType.ScatterPlot) {
             MetricCollectionTimeSeries mct = ets.iterateAcrossTracesOfEnsemblesWithMultiComputable(new PercentilesComputable(percentiles));
-            return mct.getMetricCollection(selectedZdt).getDateForStatistic(stat);
+            return mct.getMetricCollection(selectedZdt).getComputedValuesForStatistic(stat);
         }
         return null;
     }
@@ -129,21 +129,21 @@ public class StatComputationHelper {
         MetricCollectionTimeSeries mct = ets.iterateAcrossEnsembleTracesWithSingleComputable(
                 new MaxAvgDuration(value));
 
-        return mct.getMetricCollection(selectedZdt).getDateForStatistic(stat);
+        return mct.getMetricCollection(selectedZdt).getComputedValuesForStatistic(stat);
     }
 
     static private float[] computeStatFromMaxAccumDurationComputable(EnsembleTimeSeries ets, Statistics stat, ZonedDateTime selectedZdt, int value) {
         MetricCollectionTimeSeries mct = ets.iterateAcrossEnsembleTracesWithSingleComputable(
                 new MaxAccumDuration(value));
 
-        return mct.getMetricCollection(selectedZdt).getDateForStatistic(stat);
+        return mct.getMetricCollection(selectedZdt).getComputedValuesForStatistic(stat);
     }
 
     static private float[] computeStatFromTotalComputable(EnsembleTimeSeries ets, Statistics stat, ZonedDateTime selectedZdt) {
         MetricCollectionTimeSeries mct = ets.iterateAcrossEnsembleTracesWithSingleComputable(
                 new Total());
 
-        return mct.getMetricCollection(selectedZdt).getDateForStatistic(stat);
+        return mct.getMetricCollection(selectedZdt).getComputedValuesForStatistic(stat);
     }
 
     static private float[][] computeStatFromCumulativeComputable(EnsembleTimeSeries ets, ZonedDateTime selectedZdt) {


### PR DESCRIPTION
Renamed MetricCollection::getDateForStatistic to MetricCollection::getComputedValuesForStatistic since method returns computed metric values.  CHeck to see the Statistic matches the statistics label

Fix #153.