### PR TITLE
Remove Deprecated method from StatisticsReportable interface

### DIFF
--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/Ensemble.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/Ensemble.java
@@ -1,12 +1,12 @@
 package hec.ensemble;
 
-import java.time.Duration;
-import java.time.ZonedDateTime;
-
 import hec.ensemble.stats.Computable;
 import hec.ensemble.stats.Configurable;
 import hec.ensemble.stats.MultiComputable;
 import hec.ensemble.stats.SingleComputable;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
 
 /**
  * an Ensemble is an array of time-series data
@@ -124,7 +124,7 @@ public class Ensemble
         ((Configurable)cmd).configure(_configuration);
       }
       int size= values.length;
-      int size2 = cmd.Statistics().length;
+      int size2 = cmd.StatisticsLabel().split("\\|").length;
       float[] rval;
       float[][] val = new float[size2][size];
       for (int i = 0; i <size ; i++) {
@@ -146,7 +146,7 @@ public class Ensemble
         ((Configurable)cmd).configure(_configuration);
       }
       int size= values[0].length;//number of timesteps
-      int size2 = cmd.Statistics().length;
+      int size2 = cmd.StatisticsLabel().split("\\|").length;
       float[][] val = new float[size2][size];
       int traces = values.length;//number of traces
       float[] rval;

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/Ensemble.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/Ensemble.java
@@ -124,7 +124,7 @@ public class Ensemble
         ((Configurable)cmd).configure(_configuration);
       }
       int size= values.length;
-      int size2 = cmd.StatisticsLabel().split("\\|").length;
+      int size2 = cmd.getStatCount();
       float[] rval;
       float[][] val = new float[size2][size];
       for (int i = 0; i <size ; i++) {
@@ -146,7 +146,7 @@ public class Ensemble
         ((Configurable)cmd).configure(_configuration);
       }
       int size= values[0].length;//number of timesteps
-      int size2 = cmd.StatisticsLabel().split("\\|").length;
+      int size2 = cmd.getStatCount();
       float[][] val = new float[size2][size];
       int traces = values.length;//number of traces
       float[] rval;

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/CumulativeComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/CumulativeComputable.java
@@ -62,11 +62,6 @@ public class CumulativeComputable implements MultiComputable, Configurable {
     }
 
     @Override
-    public Statistics[] Statistics() {
-        return new Statistics[]{Statistics.CUMULATIVE};
-    }
-
-    @Override
     public String StatisticsLabel() {
         return "CUMULATIVE";
     }

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MaxAccumDuration.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MaxAccumDuration.java
@@ -96,11 +96,6 @@ public  class MaxAccumDuration implements Computable, Configurable {
     }
 
     @Override
-    public Statistics[] Statistics() {
-        return new Statistics[]{Statistics.MAXACCUMDURATION};//but what duration?
-    }
-
-    @Override
     public String StatisticsLabel() {
         return "MAXACCUMDURATION" + "(" + accumulatingDuration + "Hour)";
     }

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MaxAvgDuration.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MaxAvgDuration.java
@@ -83,10 +83,6 @@ public  class MaxAvgDuration implements Computable, Configurable {
         config = c;
 
     }
-    @Override
-    public Statistics[] Statistics() {
-        return new Statistics[]{Statistics.MAXAVERAGEDURATION};//but what duration?
-    }
 
     @Override
     public String StatisticsLabel() {

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MaxComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MaxComputable.java
@@ -25,10 +25,6 @@ public class MaxComputable implements Computable, Configurable {
         return getInputUnits();
     }
 
-    @Override
-    public Statistics[] Statistics() {
-        return new Statistics[]{Statistics.MAX};
-    }
 
     @Override
     public String StatisticsLabel() {

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MaxOfMaximumsComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MaxOfMaximumsComputable.java
@@ -14,12 +14,6 @@ public class MaxOfMaximumsComputable implements SingleComputable {
         return maxval;
     }
 
-
-    @Override
-    public Statistics[] Statistics() {
-        return new Statistics[]{Statistics.MAX};
-    }
-
     @Override
     public String StatisticsLabel() {
         return null;

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MeanComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MeanComputable.java
@@ -27,11 +27,6 @@ public class MeanComputable implements Computable, Configurable {
     }
 
     @Override
-    public Statistics[] Statistics() {
-        return new Statistics[]{Statistics.AVERAGE};
-    }
-
-    @Override
     public String StatisticsLabel() {
         return "AVERAGE";
     }

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MedianComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MedianComputable.java
@@ -30,11 +30,6 @@ public class MedianComputable implements Computable, Configurable {
     }
 
     @Override
-    public Statistics[] Statistics() {
-        return new Statistics[]{Statistics.MEDIAN};
-    }
-
-    @Override
     public String StatisticsLabel() {
         return "MEDIAN";
     }

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MinComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MinComputable.java
@@ -23,11 +23,6 @@ public class MinComputable implements Computable, Configurable {
     }
 
     @Override
-    public Statistics[] Statistics() {
-        return new Statistics[]{Statistics.MIN};
-    }
-
-    @Override
     public String StatisticsLabel() {
         return "MIN";
     }

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MultiComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MultiComputable.java
@@ -3,4 +3,8 @@ package hec.ensemble.stats;
 public interface MultiComputable extends StatisticsReportable {
     float[] multiCompute(float[] values);
     String getOutputUnits();
+
+    default int getStatCount() {
+        return StatisticsLabel().split("\\|").length;
+    }
 }

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MultiStatComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MultiStatComputable.java
@@ -85,11 +85,6 @@ public class MultiStatComputable implements MultiComputable, Computable, Configu
     }
 
     @Override
-    public Statistics[] Statistics() {
-        return statSelection;
-    }
-
-    @Override
     public String StatisticsLabel() {
         StringBuilder statLablel = new StringBuilder();
         int count = 0;

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/NDayMultiComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/NDayMultiComputable.java
@@ -64,19 +64,6 @@ public class NDayMultiComputable implements Computable, MultiComputable, Statist
     }
 
     @Override
-    public Statistics[] Statistics()
-    {
-        Statistics[] statsarray = new Statistics[stepOneCompute.Statistics().length+1];
-        statsarray[0] = Statistics.CUMULATIVE;
-        int count = 1;
-        for(Statistics s: stepOneCompute.Statistics()){
-            statsarray[count] = s;
-            count++;
-        }
-        return new Statistics[0];
-    }
-
-    @Override
     public String StatisticsLabel() {
         return stepOneCompute.StatisticsLabel()+"("+ accumulatingDays +"DAY)";
     }

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/PercentilesComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/PercentilesComputable.java
@@ -94,15 +94,6 @@ public class PercentilesComputable implements Computable, MultiComputable, Confi
     }
 
     @Override
-    public Statistics[] Statistics() {
-        Statistics[] ret = new Statistics[selectedPercentiles.length];
-        for (int i = 0; i < selectedPercentiles.length; i ++){
-            ret[i] = Statistics.PERCENTILE;
-        }
-        return ret;
-    }
-
-    @Override
     public String StatisticsLabel() {
         StringBuilder label = new StringBuilder();
         for (int i = 0; i < selectedPercentiles.length; i ++){

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/PlottingPositionComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/PlottingPositionComputable.java
@@ -65,11 +65,6 @@ public class PlottingPositionComputable implements MultiComputable, PlottingMeth
     }
 
     @Override
-    public Statistics[] Statistics() {
-        return new Statistics[]{Statistics.PLOTTINGPOSITION};
-    }
-
-    @Override
     public String StatisticsLabel() {
         return "PLOTTING POSITION";
     }

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/StatisticsReportable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/StatisticsReportable.java
@@ -1,7 +1,5 @@
 package hec.ensemble.stats;
 
 public interface StatisticsReportable {
-    @Deprecated
-    Statistics[] Statistics();
     String StatisticsLabel();
 }

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/Total.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/Total.java
@@ -51,11 +51,6 @@ public class Total implements Computable, Configurable {
     }
 
     @Override
-    public Statistics[] Statistics() {
-        return new Statistics[]{Statistics.TOTAL};
-    }
-
-    @Override
     public String StatisticsLabel() {
         return "TOTAL";
     }

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/TwoStepComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/TwoStepComputable.java
@@ -58,12 +58,6 @@ public class TwoStepComputable implements SingleComputable, Configurable {
         _c = c;
     }
 
-
-    @Override
-    public Statistics[] Statistics() {
-        return new Statistics[]{Statistics.COMPUTABLE};
-    }
-
     @Override
     public String StatisticsLabel() {
         return  _stepOne.StatisticsLabel() +"," + _stepTwo.StatisticsLabel();

--- a/FIRO_TSEnsembles/src/test/java/SqliteDatabaseTest.java
+++ b/FIRO_TSEnsembles/src/test/java/SqliteDatabaseTest.java
@@ -1,15 +1,11 @@
 import hec.RecordIdentifier;
 import hec.SqliteDatabase;
 import hec.VersionIdentifier;
-import hec.VersionableDatabase;
 import hec.ensemble.Ensemble;
 import hec.ensemble.EnsembleTimeSeries;
 import hec.ensemble.stats.*;
-import hec.metrics.MetricCollection;
 import hec.metrics.MetricCollectionTimeSeries;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.shadow.com.univocity.parsers.common.record.Record;
 
 import java.io.*;
 import java.nio.file.Files;


### PR DESCRIPTION
Removed deprecated method from StatisticsReportable and from all classes that Override the method.  For Ensemble class, used the updated StatisticsLabel method to parse multiple metrics.