### PR TITLE
Use JavaX Measure Library to handle units

### DIFF
--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/ConvertUnits.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/ConvertUnits.java
@@ -1,10 +1,30 @@
 package hec.ensemble.stats;
+import tech.units.indriya.function.RationalConverter;
+import javax.measure.IncommensurableException;
+import javax.measure.Unit;
+
+import static javax.measure.MetricPrefix.KILO;
+import static systems.uom.common.USCustomary.ACRE_FOOT;
+import static systems.uom.common.USCustomary.CUBIC_FOOT;
+import static tech.units.indriya.unit.Units.SECOND;
 
 public final class ConvertUnits {
     private ConvertUnits() {
     }
 
-    public static float convertCfsAcreFeet(int seconds) {
-        return (float) seconds / 43560;
+    public static Unit<?> convertStringUnits(String units) {
+        return UnitsUtil.convert(units);
+    }
+
+    public static double getAccumulationConversionFactor(Unit<?> unit) throws IncommensurableException {
+        if (unit.equals(CUBIC_FOOT.divide(SECOND)) || unit.equals(KILO(CUBIC_FOOT.divide(SECOND)))) {
+            RationalConverter rationalConverter = (RationalConverter) unit.getConverterToAny(ACRE_FOOT.divide(SECOND));
+
+            double dividend = rationalConverter.getDividend().doubleValue();
+            double divisor = rationalConverter.getDivisor().doubleValue();
+
+            return dividend/divisor;
+        }
+        return 1;
     }
 }

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/ConvertUnits.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/ConvertUnits.java
@@ -12,11 +12,11 @@ public final class ConvertUnits {
     private ConvertUnits() {
     }
 
-    public static Unit<?> convertStringUnits(String units) {
+    static Unit<?> convertStringUnits(String units) {
         return UnitsUtil.convert(units);
     }
 
-    public static double getAccumulationConversionFactor(Unit<?> unit) throws IncommensurableException {
+    static double getAccumulationConversionFactor(Unit<?> unit) throws IncommensurableException {
         if (unit.equals(CUBIC_FOOT.divide(SECOND)) || unit.equals(KILO(CUBIC_FOOT.divide(SECOND)))) {
             RationalConverter rationalConverter = (RationalConverter) unit.getConverterToAny(ACRE_FOOT.divide(SECOND));
 

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/CumulativeComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/CumulativeComputable.java
@@ -6,7 +6,7 @@ import javax.measure.Unit;
 public class CumulativeComputable implements MultiComputable, Configurable {
     private static final String DEFAULT_INPUT_UNITS = "cfs";
     private Configuration config;
-    private Unit<?> unit = null;
+    private Unit<?> unit;
 
     @Override
     public float[] multiCompute(float[] values) {

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/CumulativeComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/CumulativeComputable.java
@@ -1,38 +1,35 @@
 package hec.ensemble.stats;
 
-import org.apache.commons.lang.NotImplementedException;
-
-import static hec.ensemble.stats.ConvertUnits.convertCfsAcreFeet;
+import javax.measure.IncommensurableException;
+import javax.measure.Unit;
 
 public class CumulativeComputable implements MultiComputable, Configurable {
     private static final String DEFAULT_INPUT_UNITS = "cfs";
-    private static final long DEFAULT_INPUT_DURATION = 3600;  //seconds
-
     private Configuration config;
-    private String outputUnit;
-
+    private Unit<?> unit = null;
 
     @Override
     public float[] multiCompute(float[] values) {
-        float factor = getConversionFactor();
+        double factor = getConversionFactor();
+        long duration = getDuration();
 
         float[] flowVol = new float[values.length];
         for (int i = 0; i < flowVol.length; i++) {
-            if(i == 0) {
-                flowVol[i] = factor * values[0];
+            if (i == 0) {
+                flowVol[i] = (float) factor * (values[0]) * duration;
             } else {
-                flowVol[i] = flowVol[i - 1] + factor * values[i];
+                flowVol[i] = (float) (flowVol[i - 1] + factor * (values[i]) * duration);
             }
         }
         return flowVol;
     }
 
-    private float getConversionFactor() {
-        if(getInputUnits().equalsIgnoreCase("cfs")) {
-            outputUnit = "acre-ft";
-            return convertCfsAcreFeet((int) getDuration());
-        } else {
-            throw new NotImplementedException("Converting '"+getInputUnits()+"' to a volume is not supported");
+    private double getConversionFactor() {
+        unit = ConvertUnits.convertStringUnits(getInputUnits());
+        try {
+            return ConvertUnits.getAccumulationConversionFactor(unit);
+        } catch (IncommensurableException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -45,16 +42,12 @@ public class CumulativeComputable implements MultiComputable, Configurable {
     }
 
     private long getDuration() {
-        if(config == null) {
-            return DEFAULT_INPUT_DURATION;
-        } else {
-            return config.getDuration().getSeconds();
-        }
+        return config.getDuration().getSeconds();
     }
 
     @Override
     public String getOutputUnits() {
-        return outputUnit;
+        return UnitsUtil.getOutputUnitString(unit);
     }
 
     @Override

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MaxAccumDuration.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MaxAccumDuration.java
@@ -10,7 +10,7 @@ public  class MaxAccumDuration implements Computable, Configurable {
     private static final String DEFAULT_INPUT_UNITS = "cfs";
     Integer accumulatingDuration; //duration in hours
     Configuration config;
-    private Unit<?> unit = null;
+    private Unit<?> unit;
 
     /**
      * The max accumulated volume computes the max volume for a given duration (i.e. max 2-day volume).

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MaxAccumDuration.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MaxAccumDuration.java
@@ -42,7 +42,7 @@ public  class MaxAccumDuration implements Computable, Configurable {
 
     @Override
     public float compute(float[] values) {
-        double factor = getConversionFactor();
+        double factor = getAccumulationConversionFactor();
         long duration = getDuration();
 
         int timeSPD = timeStepsPerDuration();
@@ -64,7 +64,7 @@ public  class MaxAccumDuration implements Computable, Configurable {
         return maxVal;
     }
 
-    private double getConversionFactor() {
+    private double getAccumulationConversionFactor() {
         unit = ConvertUnits.convertStringUnits(getInputUnits());
         try {
             return ConvertUnits.getAccumulationConversionFactor(unit);

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/Total.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/Total.java
@@ -6,7 +6,7 @@ import javax.measure.Unit;
 public class Total implements Computable, Configurable {
     private static final String DEFAULT_INPUT_UNITS = "cfs";
     Configuration config;
-    private Unit<?> unit = null;
+    private Unit<?> unit;
 
     /**
      * Instantiates a total flow computable object

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/UnitsUtil.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/UnitsUtil.java
@@ -1,0 +1,105 @@
+package hec.ensemble.stats;
+
+import javax.measure.Unit;
+
+import static javax.measure.MetricPrefix.*;
+import static si.uom.NonSI.TONNE;
+import static systems.uom.common.USCustomary.*;
+import static systems.uom.common.USCustomary.HOUR;
+import static tech.units.indriya.AbstractUnit.ONE;
+import static tech.units.indriya.unit.Units.*;
+
+public class UnitsUtil {
+    public static Unit<?> convert(String units) {
+        switch (units.toLowerCase()) {
+            case "kg.m-2.s-1":
+            case "kg/m2s":
+            case "mm/s":
+                return MILLI(METRE).divide(SECOND);
+            case "mm hr^-1":
+            case "mm/hr":
+                return MILLI(METRE).divide(HOUR);
+            case "mm/day":
+            case "mm/d":
+                return MILLI(METRE).divide(DAY);
+            case "kg.m-2":
+            case "kg/m^2":
+            case "kg m^-2":
+            case "mm":
+                return MILLI(METRE);
+            case "in":
+            case "inch":
+            case "inches":
+                return INCH;
+            case "celsius":
+            case "degrees c":
+            case "deg c":
+            case "c":
+                return CELSIUS;
+            case "degc-d":
+                return CELSIUS.multiply(DAY);
+            case "fahrenheit":
+            case "degf":
+            case "deg f":
+            case "f":
+                return FAHRENHEIT;
+            case "kelvin":
+            case "k":
+                return KELVIN;
+            case "watt/m2":
+                return WATT.divide(SQUARE_METRE);
+            case "j m**-2":
+                return JOULE.divide(SQUARE_METRE);
+            case "kph":
+                return KILO(METRE).divide(HOUR);
+            case "%":
+                return PERCENT;
+            case "hpa":
+                return HECTO(PASCAL);
+            case "m":
+                return METRE;
+            case "cfs":
+            case "ft3/s":
+            case "ft^3/s":
+                return CUBIC_FOOT.divide(SECOND);
+            case "cms":
+            case "m3/s":
+            case "m^3/s":
+                return CUBIC_METRE.divide(SECOND);
+            case "cm":
+            case "m3":
+            case "m^3":
+                return CUBIC_METRE;
+            case "kcm":
+            case "km3":
+            case "km^3":
+                return KILO(CUBIC_METRE);
+            case "kcfs":
+                return KILO(CUBIC_FOOT.divide(SECOND));
+            case "kcms":
+                return KILO(CUBIC_METRE.divide(SECOND));
+            case "tonne":
+            case "tonnes":
+            case "metric ton":
+                return TONNE;
+            default:
+                return ONE;
+        }
+    }
+
+    public static String getOutputUnitString(Unit<?> unit) {
+        if (unit.equals(CUBIC_FOOT.divide(SECOND))) {
+            return "ACRE-FT";
+        } else if (unit.equals(KILO(CUBIC_FOOT.divide(SECOND)))) {
+            return "1000 ACRE-FT";
+        } else if (unit.equals(CUBIC_METRE.divide(SECOND))) {
+            return "M3";
+        } else if (unit.equals(KILO(CUBIC_METRE.divide(SECOND)))) {
+            return "1000 M3";
+        } else if (unit.equals(INCH)) {
+            return "IN";
+        }        else {
+            return unit.getName().toUpperCase();
+        }
+    }
+}

--- a/FIRO_TSEnsembles/src/test/java/hec/ensemble/MetricCollectionTimeSeriesUnitsTest.java
+++ b/FIRO_TSEnsembles/src/test/java/hec/ensemble/MetricCollectionTimeSeriesUnitsTest.java
@@ -54,7 +54,7 @@ class MetricCollectionTimeSeriesUnitsTest {
         c.configure(new EnsembleConfiguration(null, null, Duration.ofHours(1),"cfs"));
         float[] num1 = {11,2,6,4,5,6,7,8,11,2,6,4,5,6,7,8,11,2,6,4,5,6,7,8,11,2,6,4,5,6,7,8,11,2,6,4,5,6,7,8,11,2,6,4,5,6,7,8,11,2,6,4,5,6,7,8,11,2,6,4,5,6,7,8,11,2,6,4,5,6,7,8};
         float[] results = test.multiCompute(num1);
-        assertEquals("acre-ft", test.getOutputUnits());
+        assertEquals("ACRE-FT", test.getOutputUnits());
     }
 
     @Test
@@ -69,7 +69,7 @@ class MetricCollectionTimeSeriesUnitsTest {
             //compute the statistics for the entire ensemble time series
             MetricCollectionTimeSeries output = ets.iterateAcrossTracesOfEnsemblesWithMultiComputable(test);
 
-            assertEquals("acre-ft", output.getUnits());
+            assertEquals("ACRE-FT", output.getUnits());
 
             //write result
             _db.write(output);
@@ -91,7 +91,7 @@ class MetricCollectionTimeSeriesUnitsTest {
             //compute the statistics for the entire ensemble time series
             MetricCollectionTimeSeries output = ets.iterateTracesOfEnsemblesWithMultiComputable(test);
 
-            assertEquals("acre-ft", output.getUnits());
+            assertEquals("ACRE-FT", output.getUnits());
 
             //write result
             _db.write(output);

--- a/ensemble-view/src/main/java/hec/ensembleview/EnsembleViewer.java
+++ b/ensemble-view/src/main/java/hec/ensembleview/EnsembleViewer.java
@@ -10,6 +10,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class EnsembleViewer {
+    static {
+        try {
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException |
+                 UnsupportedLookAndFeelException e) {
+            throw new RuntimeException(e);
+        }
+    }
     private JTabbedPane tabPane;
     private final List<TabSpec> tabs = new ArrayList<>();
 

--- a/ensemble-view/src/main/java/hec/ensembleview/controllers/EnsembleArrayChartManager.java
+++ b/ensemble-view/src/main/java/hec/ensembleview/controllers/EnsembleArrayChartManager.java
@@ -76,10 +76,19 @@ public class EnsembleArrayChartManager extends ChartManager {
     }
 
     private void setChartLabels() {
+        String parameter = databaseHandlerService.getDbHandlerRid().parameter;
+
+        String yLabelText = parameter + " (" + units + ")";
+        chart.setYLabel(yLabelText);
+
+        if (chart instanceof EnsembleChartAcrossEnsembles) {
+            String y2LabelText = parameter + " (" + secondaryUnits + ")";
+            ((EnsembleChartAcrossEnsembles) chart).setY2Label(y2LabelText);
+        }
+
         chart.setXLabel("Ensembles");
-        chart.setYLabel(String.join("-", databaseHandlerService.getDbHandlerRid().parameter, units));
-        ((EnsembleChartAcrossEnsembles) chart).setY2Label(String.join("-", databaseHandlerService.getDbHandlerRid().parameter, secondaryUnits));
     }
+
 
     private boolean isMetricArrayOfArray(MetricCollectionTimeSeries metricCollections) {
         return metricCollections.getMetricType() == MetricTypes.ARRAY_OF_ARRAY;

--- a/ensemble-view/src/main/java/hec/ensembleview/controllers/EnsembleTimeSeriesChartManager.java
+++ b/ensemble-view/src/main/java/hec/ensembleview/controllers/EnsembleTimeSeriesChartManager.java
@@ -69,7 +69,9 @@ public class EnsembleTimeSeriesChartManager extends ChartManager {
 
     void setChartLabels() {
         chart.setXLabel("Date/Time");
-        chart.setYLabel(String.join("-", databaseHandlerService.getDbHandlerRid().parameter, units));
+
+        String yLabelText = databaseHandlerService.getDbHandlerRid().parameter + " (" + units + ")";
+        chart.setYLabel(yLabelText);
     }
 
     private boolean isMetricTimeSeries(MetricCollectionTimeSeries metricCollections) {


### PR DESCRIPTION
Update ConvertUnits class to implement javax measure library to handle unit conversions for metric computes.  Updates made to CumulativeComputable, Total, and MaxAccumDuration. Import UnitsUtil class from Vortex.