### PR TITLE
2400 hour hecTime to ZoneDateTime 

### DIFF
--- a/ensemble-dss/src/main/java/hec/dss/ensemble/DssDatabase.java
+++ b/ensemble-dss/src/main/java/hec/dss/ensemble/DssDatabase.java
@@ -170,20 +170,23 @@ public class DssDatabase implements EnsembleDatabase,MetricDatabase {
 
     private ZonedDateTime getStartDate(TimeSeriesCollectionContainer tscc) {
         HecTime time = tscc.get(0).getStartTime();
-        System.out.println(time.toString());
-
         int hour = time.hour();
         int day = time.day();
 
         // Handling 2400 hours
         if (hour == 24) {
-            day = day + 1;
-            hour = 0;
+            String hecTimeStyle = time.toString(-13);
+            String[] timeParse = hecTimeStyle.replaceAll("\\s*,\\s*", ",").split(",");
+            String date = timeParse[0];
+            String timeReset = "00:00:00";
+            String offSet = "+00:00";
+            String formatDateTime = date + "T" + timeReset + offSet;
+            return ZonedDateTime.parse(formatDateTime).plusDays(1);
+        } else {
+            return ZonedDateTime.of(time.year(), time.month(), day, hour,
+                    time.minute(), time.second(), 0,
+                    TimeZone.getTimeZone(tscc.locationTimezone).toZoneId());
         }
-
-        return ZonedDateTime.of(time.year(), time.month(), day, hour,
-                time.minute(), time.second(), 0,
-                TimeZone.getTimeZone(tscc.locationTimezone).toZoneId());
     }
 
     private TimeSeriesCollectionContainer getEnsembleCollection(List<DSSPathname> paths) {

--- a/ensemble-dss/src/main/java/hec/dss/ensemble/DssDatabase.java
+++ b/ensemble-dss/src/main/java/hec/dss/ensemble/DssDatabase.java
@@ -18,12 +18,13 @@ import hec.metrics.MetricCollectionTimeSeries;
 import org.apache.commons.lang.NotImplementedException;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 
 /**
  * DssDatabase implements EnsembleDatabase.
@@ -170,22 +171,26 @@ public class DssDatabase implements EnsembleDatabase,MetricDatabase {
 
     private ZonedDateTime getStartDate(TimeSeriesCollectionContainer tscc) {
         HecTime time = tscc.get(0).getStartTime();
-        int hour = time.hour();
-        int day = time.day();
+        return hecTimeToZonedDateTime(time);
+    }
 
-        // Handling 2400 hours
+    ZonedDateTime hecTimeToZonedDateTime(HecTime time) {
+        int hour = time.hour();
+        // Currently, assume all dss time series records in GMT. Time will appear as shown in dss record.
+        ZoneId timeZone = ZoneId.of("GMT");
+
         if (hour == 24) {
             String hecTimeStyle = time.toString(-13);
             String[] timeParse = hecTimeStyle.replaceAll("\\s*,\\s*", ",").split(",");
             String date = timeParse[0];
             String timeReset = "00:00:00";
-            String offSet = "+00:00";
-            String formatDateTime = date + "T" + timeReset + offSet;
-            return ZonedDateTime.parse(formatDateTime).plusDays(1);
+            String formatDateTime = date + "T" + timeReset;
+            LocalDateTime ldt = LocalDateTime.parse(formatDateTime);
+            return ZonedDateTime.of(ldt, timeZone).plusDays(1);
         } else {
-            return ZonedDateTime.of(time.year(), time.month(), day, hour,
+            return ZonedDateTime.of(time.year(), time.month(), time.day(), time.hour(),
                     time.minute(), time.second(), 0,
-                    TimeZone.getTimeZone(tscc.locationTimezone).toZoneId());
+                    timeZone);
         }
     }
 

--- a/ensemble-dss/src/main/java/hec/dss/ensemble/DssDatabase.java
+++ b/ensemble-dss/src/main/java/hec/dss/ensemble/DssDatabase.java
@@ -171,10 +171,10 @@ public class DssDatabase implements EnsembleDatabase,MetricDatabase {
 
     private ZonedDateTime getStartDate(TimeSeriesCollectionContainer tscc) {
         HecTime time = tscc.get(0).getStartTime();
-        return hecTimeToZonedDateTime(time);
+        return getZonedDateTime(time);
     }
 
-    ZonedDateTime hecTimeToZonedDateTime(HecTime time) {
+    static ZonedDateTime getZonedDateTime(HecTime time) {
         int hour = time.hour();
         // Currently, assume all dss time series records in GMT. Time will appear as shown in dss record.
         ZoneId timeZone = ZoneId.of("GMT");

--- a/ensemble-dss/src/test/java/hec/dss/ensemble/HecTimeToZonedDateTimeTest.java
+++ b/ensemble-dss/src/test/java/hec/dss/ensemble/HecTimeToZonedDateTimeTest.java
@@ -1,9 +1,6 @@
 package hec.dss.ensemble;
 
 import hec.heclib.util.HecTime;
-import hec.heclib.util.HecTimeArray;
-import hec.io.TimeSeriesCollectionContainer;
-import hec.io.TimeSeriesContainer;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
@@ -11,26 +8,15 @@ import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class HecTimeToZonedDateTimeTest {
+class HecTimeToZonedDateTimeTest {
     @Test
     void test24HourStartTime() {
         ZonedDateTime zdt = ZonedDateTime.of(2023, 1, 2, 0,
                 0, 0, 0,
                 TimeZone.getTimeZone("").toZoneId());
 
-        TimeSeriesCollectionContainer tscc = new TimeSeriesCollectionContainer();
-        TimeSeriesContainer tsc = new TimeSeriesContainer();
-
         HecTime t = new HecTime("01Jan2023","24:00");
-        HecTime t2 = new HecTime("01Jan2024","24:00");
-        HecTimeArray times = new HecTimeArray();
-        times.set(new int[]{t.value(),t2.value()});
-        tsc.set(new double[]{1,2},times);
-
-        tscc.add(tsc);
-        DssDatabase db = new DssDatabase("test");
-
-        assertEquals(zdt, db.hecTimeToZonedDateTime(tscc.get(0).getStartTime()));
+        assertEquals(zdt, DssDatabase.getZonedDateTime(t));
     }
 
     @Test
@@ -39,19 +25,8 @@ public class HecTimeToZonedDateTimeTest {
                 0, 0, 0,
                 TimeZone.getTimeZone("").toZoneId());
 
-        TimeSeriesCollectionContainer tscc = new TimeSeriesCollectionContainer();
-        TimeSeriesContainer tsc = new TimeSeriesContainer();
-
         HecTime t = new HecTime("31Jan2024","24:00");
-        HecTime t2 = new HecTime("01Feb2024","24:00");
-        HecTimeArray times = new HecTimeArray();
-        times.set(new int[]{t.value(),t2.value()});
-        tsc.set(new double[]{1,2},times);
-
-        tscc.add(tsc);
-        DssDatabase db = new DssDatabase("test");
-
-        assertEquals(zdt, db.hecTimeToZonedDateTime(tscc.get(0).getStartTime()));
+        assertEquals(zdt, DssDatabase.getZonedDateTime(t));
     }
 
     @Test
@@ -64,19 +39,10 @@ public class HecTimeToZonedDateTimeTest {
                 0, 0, 0,
                 TimeZone.getTimeZone("").toZoneId());
 
-        TimeSeriesCollectionContainer tscc = new TimeSeriesCollectionContainer();
-        TimeSeriesContainer tsc = new TimeSeriesContainer();
-
         HecTime t = new HecTime("28Feb2024","24:00");
         HecTime t2 = new HecTime("29Feb2024","24:00");
-        HecTimeArray times = new HecTimeArray();
-        times.set(new int[]{t.value(),t2.value()});
-        tsc.set(new double[]{1,2},times);
 
-        tscc.add(tsc);
-        DssDatabase db = new DssDatabase("test");
-
-        assertEquals(zdtStart, db.hecTimeToZonedDateTime(tscc.get(0).getStartTime()));
-        assertEquals(zdtEnd, db.hecTimeToZonedDateTime(tscc.get(0).getEndTime()));
+        assertEquals(zdtStart, DssDatabase.getZonedDateTime(t));
+        assertEquals(zdtEnd, DssDatabase.getZonedDateTime(t2));
     }
 }

--- a/ensemble-dss/src/test/java/hec/dss/ensemble/HecTimeToZonedDateTimeTest.java
+++ b/ensemble-dss/src/test/java/hec/dss/ensemble/HecTimeToZonedDateTimeTest.java
@@ -1,0 +1,82 @@
+package hec.dss.ensemble;
+
+import hec.heclib.util.HecTime;
+import hec.heclib.util.HecTimeArray;
+import hec.io.TimeSeriesCollectionContainer;
+import hec.io.TimeSeriesContainer;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HecTimeToZonedDateTimeTest {
+    @Test
+    void test24HourStartTime() {
+        ZonedDateTime zdt = ZonedDateTime.of(2023, 1, 2, 0,
+                0, 0, 0,
+                TimeZone.getTimeZone("").toZoneId());
+
+        TimeSeriesCollectionContainer tscc = new TimeSeriesCollectionContainer();
+        TimeSeriesContainer tsc = new TimeSeriesContainer();
+
+        HecTime t = new HecTime("01Jan2023","24:00");
+        HecTime t2 = new HecTime("01Jan2024","24:00");
+        HecTimeArray times = new HecTimeArray();
+        times.set(new int[]{t.value(),t2.value()});
+        tsc.set(new double[]{1,2},times);
+
+        tscc.add(tsc);
+        DssDatabase db = new DssDatabase("test");
+
+        assertEquals(zdt, db.hecTimeToZonedDateTime(tscc.get(0).getStartTime()));
+    }
+
+    @Test
+    void test24HourStartTimeMonthAddition() {
+        ZonedDateTime zdt = ZonedDateTime.of(2024, 2, 1, 0,
+                0, 0, 0,
+                TimeZone.getTimeZone("").toZoneId());
+
+        TimeSeriesCollectionContainer tscc = new TimeSeriesCollectionContainer();
+        TimeSeriesContainer tsc = new TimeSeriesContainer();
+
+        HecTime t = new HecTime("31Jan2024","24:00");
+        HecTime t2 = new HecTime("01Feb2024","24:00");
+        HecTimeArray times = new HecTimeArray();
+        times.set(new int[]{t.value(),t2.value()});
+        tsc.set(new double[]{1,2},times);
+
+        tscc.add(tsc);
+        DssDatabase db = new DssDatabase("test");
+
+        assertEquals(zdt, db.hecTimeToZonedDateTime(tscc.get(0).getStartTime()));
+    }
+
+    @Test
+    void test24HourStartTimeLeapYear() {
+        ZonedDateTime zdtStart = ZonedDateTime.of(2024, 2, 29, 0,
+                0, 0, 0,
+                TimeZone.getTimeZone("").toZoneId());
+
+        ZonedDateTime zdtEnd = ZonedDateTime.of(2024, 3, 1, 0,
+                0, 0, 0,
+                TimeZone.getTimeZone("").toZoneId());
+
+        TimeSeriesCollectionContainer tscc = new TimeSeriesCollectionContainer();
+        TimeSeriesContainer tsc = new TimeSeriesContainer();
+
+        HecTime t = new HecTime("28Feb2024","24:00");
+        HecTime t2 = new HecTime("29Feb2024","24:00");
+        HecTimeArray times = new HecTimeArray();
+        times.set(new int[]{t.value(),t2.value()});
+        tsc.set(new double[]{1,2},times);
+
+        tscc.add(tsc);
+        DssDatabase db = new DssDatabase("test");
+
+        assertEquals(zdtStart, db.hecTimeToZonedDateTime(tscc.get(0).getStartTime()));
+        assertEquals(zdtEnd, db.hecTimeToZonedDateTime(tscc.get(0).getEndTime()));
+    }
+}


### PR DESCRIPTION
Update how 2400 times are handled when converting from hecTime to ZoneDateTime. Instead of adding 1 to the day and setting the hour to 00:00, converted the hecTime to a String that can be parsed by ZoneDateTime and used the plusDays method in ZoneDateTime to increase the day.  

Fixes #231