### PR TITLE
Incorporate the use of tags to assign versions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,14 +8,13 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-
 jobs:
   build:
-
     runs-on: windows-latest
-
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up JDK 
       uses: actions/setup-java@v2
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,18 +2,16 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
 name: publish
-
 on:
   push:
     branches: [ master ]
-
 jobs:
   build:
-
     runs-on: windows-latest
-
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up JDK 
       uses: actions/setup-java@v2
       with:

--- a/FIRO_TSEnsembles/build.gradle
+++ b/FIRO_TSEnsembles/build.gradle
@@ -1,7 +1,20 @@
 import org.gradle.internal.os.OperatingSystem
+
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "gradle.plugin.com.palantir.gradle.gitversion:gradle-git-version:0.12.0-rc2"
+    }
+}
+
 plugins {
     id 'java'
     id 'maven-publish'
+    id "com.palantir.git-version" version "3.0.0"
 }
 
 repositories {
@@ -37,8 +50,32 @@ jar {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-version ="1.0-SNAPSHOT"
+task showGit () {
+    doFirst {
+        def gitInfo = versionDetails()
+        println( "Used:    " + getVersion() ) // The select version (the project.version field)
+        println( "Tag:     " + gitInfo.lastTag) // actual tag or commit hash(short) if no tag
+        println( "Hash:    " + gitInfo.gitHash) // short commit hash
+        println( "Branch:  " + gitInfo.branchName) // branch name (null if tag checkout)
+        println( "TagBuild:" + gitInfo.isCleanTag) // true if repoi is in dettached head mode(e.g. git checkout <tag>)
+    }
+}
+
+def versionLabel(gitInfo) {
+    def branch = gitInfo.branchName // all branches are snapshots, only tags get released
+    def verNum = "-SNAPSHOT"
+    def tag = gitInfo.lastTag
+    println(tag)
+    if (tag.contains("ts-")) {
+        def tagArray = tag.trim().split('-')
+        verNum = tagArray[1]
+    }
+    return branch == null ? verNum : branch + verNum
+}
+
 publishing {
+    version = versionLabel(versionDetails())
+    println("selected tag: " + version)
     publications {
         mavenJava(MavenPublication) {
             from components.java

--- a/ensemble-dss/build.gradle
+++ b/ensemble-dss/build.gradle
@@ -1,7 +1,19 @@
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "gradle.plugin.com.palantir.gradle.gitversion:gradle-git-version:0.12.0-rc2"
+    }
+}
+
 plugins {
     id 'java'
     id 'java-library'
     id 'maven-publish'
+    id "com.palantir.git-version" version "3.0.0"
 }
 dependencies {
     implementation project(":FIRO_TSEnsembles");
@@ -57,8 +69,33 @@ jar {
     dependsOn copyNatives
 }
 
-version ="1.0-SNAPSHOT"
+task showGit () {
+    doFirst {
+        def gitInfo = versionDetails()
+        println( "Used:    " + getVersion() ) // The select version (the project.version field)
+        println( "Tag:     " + gitInfo.lastTag) // actual tag or commit hash(short) if no tag
+        println( "Hash:    " + gitInfo.gitHash) // short commit hash
+        println( "Branch:  " + gitInfo.branchName) // branch name (null if tag checkout)
+        println( "TagBuild:" + gitInfo.isCleanTag) // true if repoi is in dettached head mode(e.g. git checkout <tag>)
+    }
+}
+
+def versionLabel(gitInfo) {
+    def branch = gitInfo.branchName // all branches are snapshots, only tags get released
+    def verNum = "-SNAPSHOT"
+    def tag = gitInfo.lastTag
+    println(tag)
+    if (tag.contains("dss-")) {
+        def tagArray = tag.trim().split('-')
+        verNum = tagArray[1]
+    }
+    return branch == null ? verNum : branch + verNum
+}
+
+
 publishing {
+    version = versionLabel(versionDetails())
+    println("selected tag: " + version)
     publications {
         mavenJava(MavenPublication) {
             from components.java

--- a/ensemble-view/build.gradle
+++ b/ensemble-view/build.gradle
@@ -1,10 +1,20 @@
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "gradle.plugin.com.palantir.gradle.gitversion:gradle-git-version:0.12.0-rc2"
+    }
+}
+
 plugins {
     id 'java'
     id 'application'
     id 'maven-publish'
+    id "com.palantir.git-version" version "3.0.0"
 }
-
-
 
 repositories {
     mavenCentral()
@@ -40,8 +50,33 @@ jar {
     }
 }
 
-version ="1.0.1"
+task showGit () {
+    doFirst {
+        def gitInfo = versionDetails()
+        println( "Used:    " + getVersion() ) // The select version (the project.version field)
+        println( "Tag:     " + gitInfo.lastTag) // actual tag or commit hash(short) if no tag
+        println( "Hash:    " + gitInfo.gitHash) // short commit hash
+        println( "Branch:  " + gitInfo.branchName) // branch name (null if tag checkout)
+        println( "TagBuild:" + gitInfo.isCleanTag) // true if repoi is in dettached head mode(e.g. git checkout <tag>)
+    }
+}
+
+def versionLabel(gitInfo) {
+    def branch = gitInfo.branchName // all branches are snapshots, only tags get released
+    def verNum = "-SNAPSHOT"
+    def tag = gitInfo.lastTag
+    println(tag)
+    if (tag.contains("ev-")) {
+        def tagArray = tag.trim().split('-')
+        verNum = tagArray[1]
+    }
+    return branch == null ? verNum : branch + verNum
+}
+
+
 publishing {
+    version = versionLabel(versionDetails())
+    println("selected tag: " + version)
     publications {
         mavenJava(MavenPublication) {
             from components.java


### PR DESCRIPTION
using tags to set the project version instead of changing build script