### PR TITLE
Modify DSS C-part convention for ensembles.

### DIFF
--- a/ensemble-dss/src/main/java/hec/dss/ensemble/DssDatabase.java
+++ b/ensemble-dss/src/main/java/hec/dss/ensemble/DssDatabase.java
@@ -76,10 +76,10 @@ public class DssDatabase implements EnsembleDatabase,MetricDatabase {
 
     /**
      * translation of ensemble information to a DSS Path
-     * @param e
-     * @param memberNumber
-     * @param recordID
-     * @return
+     * @param e Ensemble
+     * @param memberNumber member of ensemble
+     * @param recordID identifier
+     * @return returns path
      */
     private static String buildDssPath(Ensemble e,int memberNumber, RecordIdentifier recordID ){
 
@@ -95,7 +95,7 @@ public class DssDatabase implements EnsembleDatabase,MetricDatabase {
         DSSPathname path = new DSSPathname();
         path.setAPart("");
         path.setBPart(timeSeriesIdentifier.location);
-        path.setCPart(metricTimeseriesIdentifier+ "-" + timeSeriesIdentifier.parameter + "-" + stat);
+        path.setCPart(timeSeriesIdentifier.parameter + "-" + stat+"-" + metricTimeseriesIdentifier);
         path.setDPart("");
         path.setEPart(getEPart((int)interval.toMinutes()));
         path.setFPart(buildFpart(startDateTime, issueDate));
@@ -107,7 +107,7 @@ public class DssDatabase implements EnsembleDatabase,MetricDatabase {
         DSSPathname path = new DSSPathname();
         path.setAPart("");
         path.setBPart(timeSeriesIdentifier.location);
-        path.setCPart(metricPairedDataIdentifier + "-" + timeSeriesIdentifier.parameter + "-stats");
+        path.setCPart(timeSeriesIdentifier.parameter + "-stats-" + metricPairedDataIdentifier);
         path.setDPart("");
         path.setEPart("");
         path.setFPart(buildFpart(startDateTime, issueDate));
@@ -129,7 +129,7 @@ public class DssDatabase implements EnsembleDatabase,MetricDatabase {
      * @param t - time stamp saved in T: tag in F part
      * @param v - version of ensemble - (issue_date)
      * @param  member - ensemble member number to be in C: tag in F part
-     * @return
+     * @return returns f-part
      */
     private static String buildFpart(int member , ZonedDateTime t, ZonedDateTime v){
         return String.format("C:%06d", member)

--- a/ensemble-dss/src/main/java/hec/dss/ensemble/MetricPathTools.java
+++ b/ensemble-dss/src/main/java/hec/dss/ensemble/MetricPathTools.java
@@ -65,14 +65,14 @@ class MetricPathTools {
     }
 
     static boolean isMetricTimeSeries(String cPart) {
-        if(cPart.startsWith(DssDatabase.metricTimeseriesIdentifier)){
+        if(cPart.endsWith(DssDatabase.metricTimeseriesIdentifier)){
             return true;
         }
         return false;
     }
 
     static boolean isMetricPairedData(String cPart) {
-        if(cPart.startsWith(DssDatabase.metricPairedDataIdentifier)){
+        if(cPart.endsWith(DssDatabase.metricPairedDataIdentifier)){
             return true;
         }
         return false;

--- a/ensemble-dss/src/test/java/hec/dss/ensemble/TestDssDatabase.java
+++ b/ensemble-dss/src/test/java/hec/dss/ensemble/TestDssDatabase.java
@@ -119,16 +119,17 @@ public class TestDssDatabase {
         db.write(output);
 
         HecTimeSeries dss = new HecTimeSeries(db.getFileName());
+        String s = DssDatabase.metricTimeseriesIdentifier;
         String[] pathsToFind = new String[] {
-            "//Kanektok.BCAC1/" +DssDatabase.metricTimeseriesIdentifier+ "-flow-MAX/01Nov2013/1Hour/T:20131103-1200|V:20131103-120000|/",
-                "//Kanektok.BCAC1/" +DssDatabase.metricTimeseriesIdentifier+ "-flow-AVERAGE/01Nov2013/1Hour/T:20131103-1200|V:20131103-120000|/",
-                "//Kanektok.BCAC1/" +DssDatabase.metricTimeseriesIdentifier+ "-flow-MIN/01Nov2013/1Hour/T:20131103-1200|V:20131103-120000|/",
-                "//Kanektok.BCAC1/" +DssDatabase.metricTimeseriesIdentifier+ "-flow-MAX/01Nov2013/1Hour/T:20131104-1200|V:20131104-120000|/",
-                "//Kanektok.BCAC1/" +DssDatabase.metricTimeseriesIdentifier+ "-flow-AVERAGE/01Nov2013/1Hour/T:20131104-1200|V:20131104-120000|/",
-                "//Kanektok.BCAC1/" +DssDatabase.metricTimeseriesIdentifier+ "-flow-MIN/01Nov2013/1Hour/T:20131104-1200|V:20131104-120000|/",
-                "//Kanektok.BCAC1/" +DssDatabase.metricTimeseriesIdentifier+ "-flow-MAX/01Nov2013/1Hour/T:20131105-1200|V:20131105-120000|/",
-                "//Kanektok.BCAC1/" +DssDatabase.metricTimeseriesIdentifier+ "-flow-AVERAGE/01Nov2013/1Hour/T:20131105-1200|V:20131105-120000|/",
-                "//Kanektok.BCAC1/" +DssDatabase.metricTimeseriesIdentifier+ "-flow-MIN/01Nov2013/1Hour/T:20131105-1200|V:20131105-120000|/"
+                "//Kanektok.BCAC1/flow-MAX-"      + s + "/01Nov2013/1Hour/T:20131103-1200|V:20131103-120000|/",
+                "//Kanektok.BCAC1/flow-AVERAGE-"  + s + "/01Nov2013/1Hour/T:20131103-1200|V:20131103-120000|/",
+                "//Kanektok.BCAC1/flow-MIN-"      + s + "/01Nov2013/1Hour/T:20131103-1200|V:20131103-120000|/",
+                "//Kanektok.BCAC1/flow-MAX-"      + s + "/01Nov2013/1Hour/T:20131104-1200|V:20131104-120000|/",
+                "//Kanektok.BCAC1/flow-AVERAGE-"  + s + "/01Nov2013/1Hour/T:20131104-1200|V:20131104-120000|/",
+                "//Kanektok.BCAC1/flow-MIN-"      + s + "/01Nov2013/1Hour/T:20131104-1200|V:20131104-120000|/",
+                "//Kanektok.BCAC1/flow-MAX-"      + s + "/01Nov2013/1Hour/T:20131105-1200|V:20131105-120000|/",
+                "//Kanektok.BCAC1/flow-AVERAGE-"  + s + "/01Nov2013/1Hour/T:20131105-1200|V:20131105-120000|/",
+                "//Kanektok.BCAC1/flow-MIN-"      + s + "/01Nov2013/1Hour/T:20131105-1200|V:20131105-120000|/"
         };
 
         for (String path : pathsToFind) {
@@ -158,10 +159,11 @@ public class TestDssDatabase {
         db.write(output);
 
         HecTimeSeries dss = new HecTimeSeries(db.getFileName());
+        String s = DssDatabase.metricTimeseriesIdentifier;
         String[] pathsToFind = new String[] {
-                "//Kanektok.BCAC1/" +DssDatabase.metricTimeseriesIdentifier+ "-flow-CUMULATIVE(2.0DAY),PERCENTILES(0.95)/01Nov2013/1Hour/T:20131103-1200|V:20131103-120000|/",
-                "//Kanektok.BCAC1/" +DssDatabase.metricTimeseriesIdentifier+ "-flow-CUMULATIVE(2.0DAY),PERCENTILES(0.95)/01Nov2013/1Hour/T:20131104-1200|V:20131104-120000|/",
-                "//Kanektok.BCAC1/" +DssDatabase.metricTimeseriesIdentifier+ "-flow-CUMULATIVE(2.0DAY),PERCENTILES(0.95)/01Nov2013/1Hour/T:20131105-1200|V:20131105-120000|/",
+                "//Kanektok.BCAC1/flow-CUMULATIVE(2.0DAY),PERCENTILES(0.95)-"+s+"/01Nov2013/1Hour/T:20131103-1200|V:20131103-120000|/",
+                "//Kanektok.BCAC1/flow-CUMULATIVE(2.0DAY),PERCENTILES(0.95)-"+s+"/01Nov2013/1Hour/T:20131104-1200|V:20131104-120000|/",
+                "//Kanektok.BCAC1/flow-CUMULATIVE(2.0DAY),PERCENTILES(0.95)-"+s+"/01Nov2013/1Hour/T:20131105-1200|V:20131105-120000|/",
         };
 
         for (String path : pathsToFind) {
@@ -219,10 +221,11 @@ public class TestDssDatabase {
         //db.catalog.update();
 
         HecPairedData dss = new HecPairedData(db.getFileName());
+        String s =  DssDatabase.metricPairedDataIdentifier;
         String[] pathsToFind = new String[] {
-                "//Kanektok.BCAC1/"+ DssDatabase.metricPairedDataIdentifier+ "-flow-stats///T:20131103-1200|V:20131103-120000|/",
-                "//Kanektok.BCAC1/"+ DssDatabase.metricPairedDataIdentifier+ "-flow-stats///T:20131104-1200|V:20131104-120000|/",
-                "//Kanektok.BCAC1/"+ DssDatabase.metricPairedDataIdentifier+ "-flow-stats///T:20131105-1200|V:20131105-120000|/"
+                "//Kanektok.BCAC1/flow-stats-" + s +"///T:20131103-1200|V:20131103-120000|/",
+                "//Kanektok.BCAC1/flow-stats-" + s +"///T:20131104-1200|V:20131104-120000|/",
+                "//Kanektok.BCAC1/flow-stats-" + s +"///T:20131105-1200|V:20131105-120000|/"
         };
 
         for (String path : pathsToFind) {


### PR DESCRIPTION
This PR is exploring and seeking comments on chaining the C-Part convention for Metric statistics.

In CWMS runs ResSim Expects standard Parameters.  This change puts extra information in suffix instead of prefix

    static String metricTimeseriesIdentifier = "MetricTimeseries";
    static String metricPairedDataIdentifier = "MetricPairedData";

