### PR TITLE
Feature/TwoStepComputable-timeseries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ FIRO_TSEnsembles/delete_me3321028155427948925.sqlite
 FIRO_TSEnsembles/delete_me6470038471526261174.sqlite
 FIRO_TSEnsembles/delete_me5124707431396663684.sqlite
 .vscode/local.settings.json
+gradle.properties

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/Ensemble.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/Ensemble.java
@@ -1,9 +1,6 @@
 package hec.ensemble;
 
-import hec.ensemble.stats.Computable;
-import hec.ensemble.stats.Configurable;
-import hec.ensemble.stats.MultiComputable;
-import hec.ensemble.stats.SingleComputable;
+import hec.ensemble.stats.*;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
@@ -204,6 +201,23 @@ public class Ensemble
       }
       return cmd.compute(values);
     }
+
+
+    public float[] singleComputeForEnsembleTimeSeries(SingleTimeSeriesComputable cmd){
+      if (cmd instanceof Configurable){
+        ((Configurable)cmd).configure(_configuration);
+      }
+      return cmd.compute(values);
+    }
+
+    public float[][] multiComputeForEnsembleTimeSeries(MultiTimeSeriesComputable cmd){
+      if (cmd instanceof Configurable){
+        ((Configurable)cmd).configure(_configuration);
+      }
+      return cmd.compute(values);
+    }
+
+
 
     /**
      * iterate over each trace and its timestep.  The result is an array of time series as initial ensemble forecasts transformed based on the statistic, such as the cumulative discharge

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/EnsembleTimeSeries.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/EnsembleTimeSeries.java
@@ -1,6 +1,8 @@
 package hec.ensemble;
 
 import hec.RecordIdentifier;
+import hec.ensemble.stats.SingleTimeSeriesComputable;
+import hec.ensemble.stats.MultiTimeSeriesComputable;
 import hec.metrics.MetricCollection;
 import hec.metrics.MetricCollectionTimeSeries;
 import hec.metrics.MetricTypes;
@@ -118,6 +120,32 @@ public class EnsembleTimeSeries implements  Iterable<Ensemble>
         computedUnits = compute.getOutputUnits();
         EnsembleConfiguration ec = new EnsembleConfiguration(e.getIssueDate(),e.getStartDateTime(),e.getInterval(),computedUnits);
         MetricCollection mc = new MetricCollection(ec, compute.StatisticsLabel(), new float[][] {{result}});
+        mcts.addMetricCollection(mc);
+      }
+      return mcts;
+    }
+
+    public MetricCollectionTimeSeries computeSingleValueSummaryTimeSeriesWithSingleCompute(SingleTimeSeriesComputable compute){
+      MetricCollectionTimeSeries mcts = new MetricCollectionTimeSeries(this.timeseriesID, this.version, this.units, MetricTypes.TIMESERIES_OF_SINGLE_VALUE);
+      for (Iterator<Ensemble> it = iterator(); it.hasNext(); ) {
+        Ensemble e = it.next();
+        float[] result = e.singleComputeForEnsembleTimeSeries(compute);
+        computedUnits = compute.getOutputUnits();
+        EnsembleConfiguration ec = new EnsembleConfiguration(e.getIssueDate(),e.getStartDateTime(),e.getInterval(),computedUnits);
+        MetricCollection mc = new MetricCollection(ec, compute.StatisticsLabel(), new float[][] {result});
+        mcts.addMetricCollection(mc);
+      }
+      return mcts;
+    }
+    
+    public MetricCollectionTimeSeries computeSingleValueSummaryTimeSeriesWithMultiCompute(MultiTimeSeriesComputable compute){
+      MetricCollectionTimeSeries mcts = new MetricCollectionTimeSeries(this.timeseriesID, this.version, this.units, MetricTypes.TIMESERIES_OF_ARRAY);
+      for (Iterator<Ensemble> it = iterator(); it.hasNext(); ) {
+        Ensemble e = it.next();
+        float[][] results = e.multiComputeForEnsembleTimeSeries(compute);
+        computedUnits = compute.getOutputUnits();
+        EnsembleConfiguration ec = new EnsembleConfiguration(e.getIssueDate(),e.getStartDateTime(),e.getInterval(),computedUnits);
+        MetricCollection mc = new MetricCollection(ec, compute.StatisticsLabel(), results);
         mcts.addMetricCollection(mc);
       }
       return mcts;

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/ComputableIndex.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/ComputableIndex.java
@@ -1,0 +1,6 @@
+package hec.ensemble.stats;
+
+public interface ComputableIndex extends StatisticsReportable {
+    int compute(float[] values);
+    String getOutputUnits();
+}

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MultiTimeSeriesComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/MultiTimeSeriesComputable.java
@@ -1,0 +1,19 @@
+package hec.ensemble.stats;
+
+public interface MultiTimeSeriesComputable extends StatisticsReportable {
+    /**
+     * Computes multiple time series from ensemble data.
+     * @param values ensemble data where rows represent ensemble members and columns are time steps
+     * @return float[][] where each row is a time series for one statistic/duration
+     */
+    float[][] compute(float[][] values);
+    
+    String getOutputUnits();
+    
+    /**
+     * Returns the number of time series this computable produces
+     */
+    default int getTimeSeriesCount() {
+        return StatisticsLabel().split("\\|").length;
+    }
+}

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/NearestIndexComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/NearestIndexComputable.java
@@ -1,0 +1,53 @@
+package hec.ensemble.stats;
+
+/**
+ * Finds the index of the ensemble member whose value is closest to a target
+ * statistic. Composes with any {@link Computable} to generalize index selection.
+ *
+ * <p>Examples:
+ * <pre>
+ *   new NearestIndexComputable(new PercentilesComputable(0.95f))  // closest to 95th percentile
+ *   new NearestIndexComputable(new MaxComputable())               // the max ensemble member
+ *   new NearestIndexComputable(new MinComputable())               // the min ensemble member
+ *   new NearestIndexComputable(new MeanComputable())              // closest to the mean
+ * </pre>
+ */
+public class NearestIndexComputable implements ComputableIndex, Configurable {
+    private final Computable targetComputable;
+
+    public NearestIndexComputable(Computable targetComputable) {
+        this.targetComputable = targetComputable;
+    }
+
+    @Override
+    public int compute(float[] values) {
+        float target = targetComputable.compute(values);
+        int bestIndex = 0;
+        float bestDiff = Math.abs(values[0] - target);
+        for (int i = 1; i < values.length; i++) {
+            float diff = Math.abs(values[i] - target);
+            if (diff < bestDiff) {
+                bestDiff = diff;
+                bestIndex = i;
+            }
+        }
+        return bestIndex;
+    }
+
+    @Override
+    public String getOutputUnits() {
+        return targetComputable.getOutputUnits();
+    }
+
+    @Override
+    public String StatisticsLabel() {
+        return targetComputable.StatisticsLabel();
+    }
+
+    @Override
+    public void configure(Configuration c) {
+        if (targetComputable instanceof Configurable) {
+            ((Configurable) targetComputable).configure(c);
+        }
+    }
+}

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/PercentilesComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/PercentilesComputable.java
@@ -11,12 +11,12 @@ public class PercentilesComputable implements Computable, MultiComputable, Confi
      * Instantiates a percentile computable object
      * @param percentile is expected to be in decimal
      */
-
     public PercentilesComputable(float percentile) {
         this.selectedPercentiles = new float[] {percentile};
     }
+
     //empty constructor added to satisfy <init>() function deserializing from XML with reflection
-    public PercentilesComputable(){}
+    public PercentilesComputable() {}
 
     public PercentilesComputable(float[] percentiles) {
         this.selectedPercentiles = percentiles;
@@ -26,14 +26,57 @@ public class PercentilesComputable implements Computable, MultiComputable, Confi
     public float compute(float[] values) {
         float[] sorted = values.clone();
         Arrays.sort(sorted);
-        if(selectedPercentiles.length == 0) {
+        if (selectedPercentiles.length == 0) {
             throw new ArrayIndexOutOfBoundsException("Percentile(s) less than or equal to 1 must be entered in the text field");
         }
         return computePercentile(sorted, selectedPercentiles[0]);
     }
 
+    @Override
+    public float[] multiCompute(float[] values) {
+        int size = this.selectedPercentiles.length;
+        float[] result = new float[size];
+        float[] sorted = values.clone();
+        Arrays.sort(sorted);
+
+        for (int i = 0; i < size; i++) {
+            result[i] = computePercentile(sorted, selectedPercentiles[i]);
+        }
+        return result;
+    }
+
+    /**
+     * computePercentile must be sorted.
+     * @param values must be sorted
+     * @param interpVal is the percentile value
+     */
+    private float computePercentile(float[] values, float interpVal) {
+        if (interpVal > 1.0) {
+            throw new ArithmeticException("Percentile must be less than or equal to 1");
+        }
+        if (interpVal < 0) {
+            throw new ArithmeticException("Percentile must be greater than or equal to 0");
+        }
+
+        if (interpVal == 0) {
+            return values[0];
+        } else if (interpVal == 1.0) {
+            return values[values.length - 1];
+        } else {
+            int startIndex = (int) (interpVal * (values.length - 1));
+            int endIndex = startIndex + 1;
+
+            float x1 = (float) startIndex / (values.length - 1);
+            float x2 = (float) endIndex / (values.length - 1);
+            float y1 = values[startIndex];
+            float y2 = values[endIndex];
+
+            return LinearInterp.linInterp(x1, x2, y1, y2, interpVal);
+        }
+    }
+
     private String getInputUnits() {
-        if(config == null || config.getUnits().isEmpty()) {
+        if (config == null || config.getUnits().isEmpty()) {
             return DEFAULT_INPUT_UNITS;
         } else {
             return config.getUnits();
@@ -46,60 +89,12 @@ public class PercentilesComputable implements Computable, MultiComputable, Confi
     }
 
     @Override
-    public float[] multiCompute(float[] values) {
-        int size = this.selectedPercentiles.length;
-        float[] result = new float[size];
-        int i = 0;
-        float[] sorted = values.clone();
-        Arrays.sort(sorted);
-
-        for (float p: this.selectedPercentiles) {
-            result[i] = computePercentile(sorted, p);
-            i++;
-        }
-        return result;
-    }
-    /**
-     * computePercentile must be sorted.
-     * @param values must be sorted
-     * @param interpVal is the percentile value
-     */
-
-    private float computePercentile(float[] values, float interpVal) {
-        if (interpVal > 1.0) {
-            throw new ArithmeticException("Percentile must be less than or equal to 1");
-        }
-        if (interpVal < 0) {
-            throw new ArithmeticException("Percentile must be greater than or equal to 0");
-        }
-
-        if (interpVal == 0) {
-            return values[0];
-        } else {
-            if (interpVal == 1.0) {
-                return values[values.length - 1];
-            } else {
-                int startIndex = (int) (interpVal * (values.length-1));
-                int endIndex = startIndex + 1;
-
-                float x1 = (float) startIndex / (values.length - 1);
-                float x2 = (float) endIndex / (values.length - 1);
-                float y1 = values[startIndex];
-                float y2 = values[endIndex];
-
-                return LinearInterp.linInterp(x1, x2, y1, y2, interpVal);
-            }
-        }
-    }
-
-    @Override
     public String StatisticsLabel() {
         StringBuilder label = new StringBuilder();
-        for (int i = 0; i < selectedPercentiles.length; i ++){
-            if(i == selectedPercentiles.length-1){
+        for (int i = 0; i < selectedPercentiles.length; i++) {
+            if (i == selectedPercentiles.length - 1) {
                 label.append(Statistics.PERCENTILES).append("(").append(selectedPercentiles[i]).append(")");
-            }
-            else{
+            } else {
                 label.append(Statistics.PERCENTILES).append("(").append(selectedPercentiles[i]).append(")|");
             }
         }

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/SingleTimeSeriesComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/SingleTimeSeriesComputable.java
@@ -1,0 +1,7 @@
+package hec.ensemble.stats;
+
+public interface SingleTimeSeriesComputable extends StatisticsReportable{
+    float[] compute(float[][] values);
+    String getOutputUnits();
+
+}

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/TwoStepMultiTimeSeriesComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/TwoStepMultiTimeSeriesComputable.java
@@ -1,0 +1,64 @@
+package hec.ensemble.stats;
+
+public class TwoStepMultiTimeSeriesComputable implements MultiTimeSeriesComputable, Configurable {
+
+    private MultiComputable _stepOne;
+    private ComputableIndex _stepTwo;
+
+    Configuration _c;
+
+    /**
+     * The multi time series two step computable computes multiple time series based on 
+     * the MultiComputable's statistics count (e.g., one time series per nDay duration).
+     * Each statistic from step one is processed through step two to select the appropriate ensemble member.
+     */
+
+    public TwoStepMultiTimeSeriesComputable(MultiComputable stepOne, ComputableIndex stepTwo) {
+        _stepOne = stepOne;
+        _stepTwo = stepTwo;
+    }
+
+    //necessary for reflection.
+    public TwoStepMultiTimeSeriesComputable() { }
+
+    public float[][] compute(float[][] values) {
+        /*    row represents ensemble members
+         columns are time steps*/
+        if (_stepOne instanceof Configurable && _c != null){
+            ((Configurable)_stepOne).configure(_c);
+        }
+
+        int statCount = _stepOne.getStatCount();
+        float[][] result = new float[statCount][];
+        
+        // Process each statistic separately
+        for (int statIndex = 0; statIndex < statCount; statIndex++) {
+            float[] rows = new float[values.length];  //returns the length of rows
+            
+            for (int i = 0; i < values.length; i++) {
+                float[] multiResults = _stepOne.multiCompute(values[i]);
+                rows[i] = multiResults[statIndex]; // Use the specific statistic for this iteration
+            }
+
+            int selectedEnsemble = _stepTwo.compute(rows);
+            result[statIndex] = values[selectedEnsemble];
+        }
+
+        return result;
+    }
+
+    @Override
+    public String getOutputUnits() {
+        return _stepOne.getOutputUnits();
+    }
+
+    @Override
+    public void configure(Configuration c) {
+        _c = c;
+    }
+
+    @Override
+    public String StatisticsLabel() {
+        return _stepOne.StatisticsLabel() + "," + _stepTwo.StatisticsLabel();
+    }
+}

--- a/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/TwoStepSingleTimeSeriesComputable.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/ensemble/stats/TwoStepSingleTimeSeriesComputable.java
@@ -1,0 +1,58 @@
+package hec.ensemble.stats;
+
+public class TwoStepSingleTimeSeriesComputable implements SingleTimeSeriesComputable, Configurable {
+
+    private Computable _stepOne;
+    private ComputableIndex _stepTwo;
+
+    Configuration _c;
+
+    /**
+     * The two step computable computes two computable object in sequence either across time or across ensembles.
+     * Compute across time outputs a single value per ensemble.  Compute across ensembles outputs a single timeseries
+     */
+
+    public TwoStepSingleTimeSeriesComputable(Computable stepOne, ComputableIndex stepTwo) {
+        _stepOne = stepOne;
+        _stepTwo = stepTwo;
+
+    }
+
+    //necessary for reflection.
+    public TwoStepSingleTimeSeriesComputable(){ }
+
+
+    public float[] compute(float[][] values) {
+    /*    row represents ensemble members
+     columns are time steps*/
+        if (_stepOne instanceof Configurable && _c != null){
+            ((Configurable)_stepOne).configure(_c);
+        }
+
+        float[] rows = new float[values.length];  //returns the length of rows
+        for (int i = 0; i < values.length; i++) {
+            float row = _stepOne.compute(values[i]);
+            rows[i] = row;
+        }
+
+        int result = _stepTwo.compute(rows);
+
+        return values[result];
+
+    }
+
+    @Override
+    public String getOutputUnits() {
+        return _stepOne.getOutputUnits();
+    }
+
+    @Override
+    public void configure(Configuration c) {
+        _c = c;
+    }
+
+    @Override
+    public String StatisticsLabel() {
+        return  _stepOne.StatisticsLabel() +"," + _stepTwo.StatisticsLabel();
+    }
+}

--- a/FIRO_TSEnsembles/src/main/java/hec/metrics/MetricTypes.java
+++ b/FIRO_TSEnsembles/src/main/java/hec/metrics/MetricTypes.java
@@ -3,5 +3,6 @@ package hec.metrics;
 public enum MetricTypes {
     SINGLE_VALUE,//all values of an ensemble condensed into one.
     ARRAY_OF_ARRAY, //all timestep values of a trace condensed to an array of statistics as an array of array values for each trace
-    TIMESERIES_OF_ARRAY; //all traces condensed to an array of values for each timestep
+    TIMESERIES_OF_ARRAY, //all traces condensed to an array of values for each timestep
+    TIMESERIES_OF_SINGLE_VALUE ; // single trace that represents a statistical metric of an ensemble
 }

--- a/FIRO_TSEnsembles/src/test/java/hec/ensemble/EnsembleTimeSeriesTest.java
+++ b/FIRO_TSEnsembles/src/test/java/hec/ensemble/EnsembleTimeSeriesTest.java
@@ -20,6 +20,8 @@ class EnsembleTimeSeriesTest {
     private static String _fn = TestingPaths.instance.getTempDir()+"/importCsvToDatabaseMutable.db";
     private static SqliteDatabase _db = null;
     private static File f;
+
+
     @BeforeAll
     static void prepareNewDatabase() throws Exception {
         //ensure no previous test db exists.

--- a/FIRO_TSEnsembles/src/test/java/hec/ensemble/MetricCollectionTimeSeriesUnitsTest.java
+++ b/FIRO_TSEnsembles/src/test/java/hec/ensemble/MetricCollectionTimeSeriesUnitsTest.java
@@ -2,10 +2,8 @@ package hec.ensemble;
 
 import hec.RecordIdentifier;
 import hec.SqliteDatabase;
-import hec.ensemble.stats.Configurable;
-import hec.ensemble.stats.CumulativeComputable;
-import hec.ensemble.stats.MultiComputable;
-import hec.ensemble.stats.NDayMultiComputable;
+import hec.ensemble.stats.*;
+import hec.metrics.MetricCollection;
 import hec.metrics.MetricCollectionTimeSeries;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -49,6 +47,102 @@ class MetricCollectionTimeSeriesUnitsTest {
         //write ensemble time series to database for use in other tests.
         db.write(ets);
         _db =  db;
+    }
+
+
+    @Test
+    public void testMetricCollectionAsTimeSeries_TwoStepSingleDuration() throws Exception {
+
+        try {
+
+            float[] nDayDuration = new float[]{2.0f};
+            float targetPercentile = (float) 0.95;
+            ZonedDateTime issueDate1 = ZonedDateTime.of(2013, 11, 3, 12, 0, 0, 0, ZoneId.of("GMT"));
+            RecordIdentifier id = new hec.RecordIdentifier("Kanektok.BCAC1", "flow");
+            EnsembleTimeSeries ets = _db.getEnsembleTimeSeries(id);
+
+            //Step One
+            MultiComputable cumulativeComputable = new CumulativeComputable();
+            Computable cumulative = new NDayMultiComputable(cumulativeComputable, nDayDuration);
+
+            //Step Two
+            ComputableIndex percentileIndexCompute = new NearestIndexComputable(new PercentilesComputable(targetPercentile));
+            SingleTimeSeriesComputable twoStep = new TwoStepSingleTimeSeriesComputable(cumulative, percentileIndexCompute);
+            MetricCollectionTimeSeries output = ets.computeSingleValueSummaryTimeSeriesWithSingleCompute(twoStep);
+            _db.write(output);
+
+            //Get N-Day volumes for the first issue ensemble
+            Ensemble e = ets.getEnsemble(issueDate1);
+            Computable test = new NDayMultiComputable(new CumulativeComputable(), nDayDuration);
+            float[] checkEnsembleVolumes = e.iterateForTracesAcrossTime(test);
+
+            //find the exact percentile volume
+            PercentilesComputable checkEnsemblePercentileVolume = new PercentilesComputable(targetPercentile);
+            float[] checkExactPercentile = checkEnsemblePercentileVolume.multiCompute(checkEnsembleVolumes);
+
+            //Convert first output hydrograph volume
+            MultiComputable testOutput = new NDayMultiComputable(new CumulativeComputable(), nDayDuration);
+            Configurable c = (Configurable) testOutput;
+            c.configure(new EnsembleConfiguration(null, null, Duration.ofHours(1), ""));
+            float[] value0 = output.iterator().next().getValues()[0];
+            float[] results = testOutput.multiCompute(value0);
+
+            // make sure metric collection is closest to what we want
+            int startIndex = (int) (targetPercentile * (checkEnsembleVolumes.length - 1));
+            int endIndex = startIndex + 1;
+
+            if (Math.abs(checkExactPercentile[0] - checkEnsembleVolumes[startIndex]) < Math.abs(checkExactPercentile[0] - checkEnsembleVolumes[endIndex])) {
+                assertEquals(results[0], checkEnsembleVolumes[startIndex]);
+            } else {
+                assertEquals(results[0], checkEnsembleVolumes[endIndex]);
+            }
+
+        } catch (Exception e) {
+            Logger.logError(e);
+            fail();
+        }
+    }
+
+    @Test
+    public void testMetricCollectionAsTimeSeries_TwoStepMultipleDurations() throws Exception {
+
+        try {
+
+            float[] nDayDurations = new float[]{2.0f, 3.0f};
+            float targetPercentile = (float) 0.95;
+            ZonedDateTime issueDate1 = ZonedDateTime.of(2013, 11, 3, 12, 0, 0, 0, ZoneId.of("GMT"));
+            RecordIdentifier id = new hec.RecordIdentifier("Kanektok.BCAC1", "flow");
+            EnsembleTimeSeries ets = _db.getEnsembleTimeSeries(id);
+
+            //Step One - NDayMultiComputable with multiple durations
+            MultiComputable cumulativeComputable = new CumulativeComputable();
+            NDayMultiComputable cumulative = new NDayMultiComputable(cumulativeComputable, nDayDurations);
+
+            //Step Two  
+            ComputableIndex percentileIndexCompute = new NearestIndexComputable(new PercentilesComputable(targetPercentile));
+            MultiTimeSeriesComputable twoStep = new TwoStepMultiTimeSeriesComputable(cumulative, percentileIndexCompute);
+            
+            // This now returns multiple time series, one for each duration
+            MetricCollectionTimeSeries output = ets.computeSingleValueSummaryTimeSeriesWithMultiCompute(twoStep);
+            _db.write(output);
+            
+            MetricCollection result = output.getMetricCollection(issueDate1);
+            float[][] outputTimeseries = result.getValues();
+            
+            // Verify output has the expected number of time series (one per duration)  
+            assertEquals(nDayDurations.length, outputTimeseries.length, 
+                        "Should have one time series for each duration");
+            
+            // Verify statistics label is exactly what we expect
+            String expectedLabel = "CUMULATIVE(2.0DAY)|CUMULATIVE(3.0DAY),PERCENTILES(0.95)";
+            String actualLabel = twoStep.StatisticsLabel();
+            assertEquals(expectedLabel, actualLabel, 
+                      "Statistics label should exactly match expected format");
+
+        } catch (Exception e) {
+            Logger.logError(e);
+            fail();
+        }
     }
 
     @Test

--- a/FIRO_TSEnsembles/src/test/java/hec/ensemble/stats/NearestIndexComputableTest.java
+++ b/FIRO_TSEnsembles/src/test/java/hec/ensemble/stats/NearestIndexComputableTest.java
@@ -1,0 +1,68 @@
+package hec.ensemble.stats;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NearestIndexComputableTest {
+
+    private final float[] values = {50, 10, 80, 30, 70, 20, 60, 40};
+
+    @Test
+    void testNearestToMax() {
+        ComputableIndex computable = new NearestIndexComputable(new MaxComputable());
+        int index = computable.compute(values);
+        assertEquals(2, index); // values[2] = 80 is the max
+    }
+
+    @Test
+    void testNearestToMin() {
+        ComputableIndex computable = new NearestIndexComputable(new MinComputable());
+        int index = computable.compute(values);
+        assertEquals(1, index); // values[1] = 10 is the min
+    }
+
+    @Test
+    void testNearestToMean() {
+        // mean = (50+10+80+30+70+20+60+40)/8 = 45
+        // values[0]=50 (diff=5) is found first in linear scan among ties
+        ComputableIndex computable = new NearestIndexComputable(new MeanComputable());
+        int index = computable.compute(values);
+        assertEquals(0, index);
+    }
+
+    @Test
+    void testNearestToMedian() {
+        ComputableIndex computable = new NearestIndexComputable(new MedianComputable());
+        int index = computable.compute(values);
+        // median of sorted {10,20,30,40,50,60,70,80} = (40+50)/2 = 45
+        // values[0]=50 (diff=5) is found first
+        assertEquals(0, index);
+    }
+
+    @Test
+    void testNearestToPercentileHigh() {
+        ComputableIndex nearest = new NearestIndexComputable(new PercentilesComputable(0.95f));
+        float[] testValues = {1, 2, 3, 4, 5, 6, 7, 8};
+        int index = nearest.compute(testValues);
+        assertEquals(7, index); // values[7]=8, closest to 95th percentile (7.65)
+    }
+
+    @Test
+    void testNearestToPercentileLow() {
+        ComputableIndex nearest = new NearestIndexComputable(new PercentilesComputable(0.05f));
+        float[] testValues = {1, 2, 3, 4, 5, 6, 7, 8};
+        int index = nearest.compute(testValues);
+        assertEquals(0, index); // values[0]=1, closest to 5th percentile (1.35)
+    }
+
+    @Test
+    void testNearestToPercentileUnsortedInput() {
+        ComputableIndex nearest = new NearestIndexComputable(new PercentilesComputable(0.5f));
+        float[] testValues = {50, 10, 80, 30, 70, 20, 60, 40};
+        int index = nearest.compute(testValues);
+        // 50th percentile of sorted {10,20,30,40,50,60,70,80} = 45
+        // values[0]=50 (diff=5) is found first in linear scan
+        assertEquals(0, index);
+    }
+}

--- a/FIRO_TSEnsembles/src/test/java/hec/ensemble/stats/TwoStepComputableTest.java
+++ b/FIRO_TSEnsembles/src/test/java/hec/ensemble/stats/TwoStepComputableTest.java
@@ -4,7 +4,6 @@ import hec.ensemble.Ensemble;
 import hec.ensemble.EnsembleConfiguration;
 import hec.ensemble.Logger;
 import hec.ensemble.TestData;
-import hec.ensemble.stats.*;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;


### PR DESCRIPTION
relates to #257 

This PR is conceptually similar to `getClosestVolEnsembleMember` from the rts-forecast-processor-plugin but is implemented here to work within the SQLite database format.

Add feature to select ensemble members representing percentile n-day volume
- Add NearestIndexComputable.
- Add SingleTimeSeriesComputable.
- Add TwoStepSingleTimeSeriesComputable to distill n-day cumulative NEP volume into a representative trace.
Outputs MetricTypes.TIMESERIES_OF_SINGLE_VALUE.
- Add TwoStepMultiTimeSeriesComputable to extract multiple n-day cumulative NEP volumes into a smaller ensemble.
Outputs MetricTypes.TIMESERIES_OF_ARRAY.
- Add computeSingleValueSummaryTimeSeries to EnsembleTimeSeries.
- Add MultiTimeSeriesComputable to support returning multiple time series.
- Add unit test testMetricCollectionAsTimeSeries_TwoStepSingleDuration() in MetricCollectionTimeSeriesUnitsTest.
- Add unit test testMetricCollectionAsTimeSeries_TwoStepMultipleDurations() to MetricCollectionTimeSeriesUnitsTest.java
- Add NearestIndexComputableTest