### PR TITLE
Removed import org.apache.commons.lang.NotImplementedException;

### DIFF
--- a/ensemble-dss/src/main/java/hec/dss/ensemble/DssDatabase.java
+++ b/ensemble-dss/src/main/java/hec/dss/ensemble/DssDatabase.java
@@ -15,7 +15,6 @@ import hec.io.TimeSeriesCollectionContainer;
 import hec.io.TimeSeriesContainer;
 import hec.metrics.MetricCollection;
 import hec.metrics.MetricCollectionTimeSeries;
-import org.apache.commons.lang.NotImplementedException;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -374,23 +373,23 @@ public class DssDatabase implements EnsembleDatabase,MetricDatabase {
     }*/
 
     @Override
-    public List<hec.metrics.MetricCollectionTimeSeries> getMetricCollectionTimeSeries(hec.RecordIdentifier timeseriesID) throws NotImplementedException{
-        throw new NotImplementedException();
+    public List<hec.metrics.MetricCollectionTimeSeries> getMetricCollectionTimeSeries(hec.RecordIdentifier timeseriesID) throws UnsupportedOperationException{
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    public hec.metrics.MetricCollectionTimeSeries getMetricCollectionTimeSeries(hec.RecordIdentifier timeseriesID, String statistic) throws NotImplementedException {
-        throw new NotImplementedException();
+    public hec.metrics.MetricCollectionTimeSeries getMetricCollectionTimeSeries(hec.RecordIdentifier timeseriesID, String statistic) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    public Map<RecordIdentifier, List<String>> getMetricStatistics() throws NotImplementedException {
-        throw new NotImplementedException();
+    public Map<RecordIdentifier, List<String>> getMetricStatistics() throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    public List<String> getMetricStatistics(hec.RecordIdentifier timeseriesID) throws NotImplementedException {
-        throw new NotImplementedException();
+    public List<String> getMetricStatistics(hec.RecordIdentifier timeseriesID) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
     }
 
     private float[][] getMetricValues(List<DSSPathname> paths) {


### PR DESCRIPTION
Replaced all usages (throw new NotImplementedException() and the matching throws clauses) in getMetricCollectionTimeSeries(...) (x2) and getMetricStatistics(...) (x2) with UnsupportedOperationException. A repo-wide audit confirmed commons-lang 2.x had no other usages in ensemble-dss or ensemble-view (the only remaining reference was a code comment in FIRO_TSEnsembles/.../Statistics.java), so the library no longer depends on Commons Lang 2.x at all and no downstream build.gradle change is required.